### PR TITLE
Fix hugging face download

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,9 +19,11 @@ if not os.path.exists(current_dir):
 model_path = os.path.join(current_dir, "isnetis.onnx")
 if not os.path.exists(model_path):
     huggingface_hub.hf_hub_download(
-        "skytnt/anime-seg",
-        local_dir=model_path,
-    )
+    repo_id="skytnt/anime-seg",
+    filename="isnetis.onnx",
+    local_dir=current_dir,
+    local_dir_use_symlinks=False
+)
 rmbg_model = rt.InferenceSession(model_path, providers=ort_providers["CPU"])
 
 


### PR DESCRIPTION
Before: 
`
Traceback (most recent call last): File "/home/luc/ComfyUI-Installs/ComfyUI/ComfyUI/nodes.py", line 2227, in load_custom_node module_spec.loader.exec_module(module) ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^ File "<frozen importlib._bootstrap_external>", line 1023, in exec_module File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed File "/home/luc/ComfyUI-Installs/ComfyUI/ComfyUI/custom_nodes/comfyui-anime-seg/__init__.py", line 21, in <module> huggingface_hub.hf_hub_download( ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ "skytnt/anime-seg", ^^^^^^^^^^^^^^^^^^^ local_dir=model_path, ^^^^^^^^^^^^^^^^^^^^^ ) ^ File "/home/luc/ComfyUI-Installs/ComfyUI/envs/default/lib/python3.13/site-packages/huggingface_hub/utils/_validators.py", line 89, in _inner_fn return fn(*args, **kwargs) TypeError: hf_hub_download() missing 1 required positional argument: 'filename'
`


With this pr it installs the model itself.